### PR TITLE
fix formatting for projects in different views

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@
 							<p> Below I have included information about my most recent projects. For more information, feel free to contact me. </p>
 
 							<div class="row">
-								<div class="col-6 col-6-mobile">
+								<div class="col-6 col-12-mobile">
 									<article class="item">
 										<div class="image fit">
 											<img src="images/bunch.jpg" alt="Bunch" />
@@ -136,48 +136,44 @@
 											<h3>Bunch</h3>
 											<h3 class="alt">Senior Design Course Project</h3>
 											<div class="row">
-												<div class="col-2 col-2-mobile"></div>
-												<div class="col-2 col-2-mobile"> 
+												<div class="col-3  col-3-normal col-6-mobile col-6-wide"> 
 												<a href="https://bunch-coronacrew.herokuapp.com" target="_blank" class="small">Website</a>
 												</div>
 
-												<div class="col-2 col-2-mobile"> 
+												<div class="col-3 col-3-normal col-6-mobile col-6-wide"> 
 												<a href="files/bunch-report.pdf" target="_blank" class="small">Report</a>
 												</div>
 
-												<div class="col-2 col-2-mobile"> 
+												<div class="col-3 col-3-normal col-6-mobile col-6-wide"> 
 												<a href="files/bunch-presentation.pdf" target="_blank" class="small">Presentation</a>
 												</div>
 
-												<div class="col-2 col-2-mobile"> 
+												<div class="col-3 col-3-normal col-6-mobile col-6-wide"> 
 												<a href="files/bunch-poster.pdf" target="_blank" class="small">Poster</a>
 												</div>
-												<div class="col-2 col-2-mobile"></div>
 											</div>
 										</header>
 									</article>
 								</div>
 								
-								<div class="col-6 col-6-mobile">
+								<div class="col-6 col-12-mobile">
 									<article class="item">
 										<a href="#" class="image fit"><img src="images/participationtracker.jpg" alt="" /></a>
 										<header>
 											<h3>Participation Tracker</h3>
 											<h3 class="alt">Software Engineering Course Project</h3>
 											<div class="row">
-												<div class="col-2-5 col-2-5-mobile"></div>
-												<div class="col-2-5 col-2-5-mobile"> 
+												<div class="col-4 col-4-normal col-6-mobile"> 
 												<a href="https://tamu-paid.herokuapp.com/" target="_blank" class="small">Website</a>
 												</div>
 
-												<div class="col-2-5 col-2-5-mobile"> 
+												<div class="col-4 col-4-normal col-6-mobile"> 
 												<a href="files/paid-report.pdf" target="_blank" class="small">Report</a>
 												</div>
 
-												<div class="col-2-5 col-2-5-mobile"> 
+												<div class="col-4 col-4-normal off-3-mobile col-6-mobile"> 
 												<a href="files/paid-presentation.pdf" target="_blank" class="small">Presentation</a>
 												</div>
-												<div class="col-2-5 col-2-5-mobile"></div>
 											</div>
 										</header>
 									</article>


### PR DESCRIPTION
This PR changes formatting of the projects section depending on screen size. It focuses on changing both the card layout and the link layout within each card. 
> * [iPhone SE, iPhone 8 and iPhone 8 Plus](#mobile)
> * [iPad mini, iPad, iPad Pro](#normal)
> * [Computer Screens (some normal, some wide)](#wide)

### Mobile
<img width="144" alt="Screen Shot 2021-02-04 at 12 45 10 PM" src="https://user-images.githubusercontent.com/67386377/106940371-17572e00-66e7-11eb-999c-cf2672c8e140.png">

### Normal
<img width="527" alt="Screen Shot 2021-02-04 at 12 49 03 PM" src="https://user-images.githubusercontent.com/67386377/106940861-af551780-66e7-11eb-8f76-80fb1699f02e.png">

### Wide
<img width="686" alt="Screen Shot 2021-02-04 at 12 52 08 PM" src="https://user-images.githubusercontent.com/67386377/106941025-e4fa0080-66e7-11eb-868d-1fdcaf75ebb2.png">



