### PR TITLE
fixed icon spacing with screen change

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2091,8 +2091,8 @@ input, select, textarea {
 			font-variant: normal;
 			text-rendering: auto;
 			line-height: 1em;
-			margin-top: 6px;
-			margin-bottom: 4px;
+			margin-top: 4px;
+			margin-bottom: 0px;
 			text-transform: none !important;
 			font-family: 'Font Awesome 5 Free';
 			font-weight: 400;


### PR DESCRIPTION
Fixed icon spacing when screen size changes.

Before
<img width="226" alt="Screen Shot 2021-02-04 at 3 58 13 PM" src="https://user-images.githubusercontent.com/67386377/106960593-eafcdb00-6701-11eb-843a-aba85eb620b9.png">

After
<img width="225" alt="Screen Shot 2021-02-04 at 3 58 36 PM" src="https://user-images.githubusercontent.com/67386377/106960545-dfa9af80-6701-11eb-81a5-6db5c6236752.png">

